### PR TITLE
Fixed typo in .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,5 @@ SNOWFLAKE_INCOMPLETE_TABLE="incomplete_events"
 
 # GCP (BigQuery) specific settings
 GCP_PROJECT_ID = "your-gcp-project-id"
-BIGQUERY_DATASET = "dataset"z
+BIGQUERY_DATASET = "dataset"
 BIGQUERY_TABLE = "table"


### PR DESCRIPTION
Spotted a typo